### PR TITLE
Simplify dataclass fields, new tests

### DIFF
--- a/tests/inputs/features/features.proto
+++ b/tests/inputs/features/features.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 package features;
@@ -14,7 +15,6 @@ message Foo {
     Bar child = 2;
 }
 
-// Enums as int json
 enum Enum {
     ZERO = 0;
     ONE = 1;
@@ -24,7 +24,6 @@ message EnumMsg {
     Enum enum = 1;
 }
 
-// Unknown fields
 message Newer {
     bool x = 1;
     int32 y = 2;
@@ -35,7 +34,6 @@ message Older {
     bool x = 1;
 }
 
-// Oneof support
 message IntMsg {
     int32 val = 1;
 }
@@ -51,7 +49,6 @@ message OneofMsg {
     }
 }
 
-// JSON casing
 message JsonCasingMsg {
     int32 pascal_case = 1;
     int32 camel_case = 2;
@@ -59,7 +56,6 @@ message JsonCasingMsg {
     int32 kabob_case = 4;
 }
 
-// Optional fields
 message OptionalBoolMsg {
     google.protobuf.BoolValue field = 1;
 }
@@ -68,10 +64,44 @@ message OptionalDatetimeMsg {
     google.protobuf.Timestamp field = 1;
 }
 
-// Other message definitions
+message Empty {}
+
+message TimeMsg {
+    google.protobuf.Timestamp timestamp = 1;
+    google.protobuf.Duration duration = 2;
+}
+
 message MsgA {
     int32 some_int = 1;
     double some_double = 2;
     string some_str = 3;
     bool some_bool = 4;
+}
+
+message MsgB {
+    int32 some_int = 1;
+    double some_double = 2;
+    string some_str = 3;
+    bool some_bool = 4;
+    int32 some_default_int = 5;
+    double some_default_double = 6;
+    string some_default_str = 7;
+    bool some_default_bool = 8;
+}
+
+message MsgC {
+    oneof group1 {
+        int32 int_field = 1;
+        string string_field = 2;
+        Empty empty_field = 3;
+    }
+}
+
+message MsgD {
+    repeated google.protobuf.Timestamp timestamps = 1;
+}
+
+message MsgE {
+    bool bool_field = 1;
+    optional int32 int_field = 2;
 }

--- a/tests/inputs/features/features.proto
+++ b/tests/inputs/features/features.proto
@@ -1,0 +1,49 @@
+syntax = "proto3";
+
+package features;
+
+message Bar {
+    string name = 1;
+}
+
+message Foo {
+    string name = 1;
+    Bar child = 2;
+}
+
+// Enums as int json
+enum Enum {
+    ZERO = 0;
+    ONE = 1;
+}
+
+message EnumMsg {
+    Enum enum = 1;
+}
+
+// Unknown fields
+message Newer {
+    bool x = 1;
+    int32 y = 2;
+    string z = 3;
+}
+
+message Older {
+    bool x = 1;
+}
+
+// Oneof support
+message IntMsg {
+    int32 val = 1;
+}
+
+message OneofMsg {
+    oneof group1 {
+        int32 x = 1;
+        string y = 2;
+    }
+    oneof group2 {
+        IntMsg a = 3;
+        string b = 4;
+    }
+}

--- a/tests/inputs/features/features.proto
+++ b/tests/inputs/features/features.proto
@@ -1,5 +1,8 @@
 syntax = "proto3";
 
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
+
 package features;
 
 message Bar {
@@ -46,4 +49,29 @@ message OneofMsg {
         IntMsg a = 3;
         string b = 4;
     }
+}
+
+// JSON casing
+message JsonCasingMsg {
+    int32 pascal_case = 1;
+    int32 camel_case = 2;
+    int32 snake_case = 3;
+    int32 kabob_case = 4;
+}
+
+// Optional fields
+message OptionalBoolMsg {
+    google.protobuf.BoolValue field = 1;
+}
+
+message OptionalDatetimeMsg {
+    google.protobuf.Timestamp field = 1;
+}
+
+// Other message definitions
+message MsgA {
+    int32 some_int = 1;
+    double some_double = 2;
+    string some_str = 3;
+    bool some_bool = 4;
 }

--- a/tests/inputs/pickling/pickling.proto
+++ b/tests/inputs/pickling/pickling.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+
+package pickling;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/struct.proto";
+
+
+message Test {}
+
+message Fe {
+    string abc = 1;
+}
+
+message Fi {
+    string abc = 1;
+}
+
+message Fo {
+    string abc = 1;
+}
+
+message NestedData {
+    map<string, google.protobuf.Struct> struct_foo = 1;
+    map<string, google.protobuf.Any> map_str_any_bar = 2;
+}
+
+message Complex {
+    string foo_str = 1;
+    oneof grp {
+        Fe fe = 3;
+        Fi fi = 4;
+        Fo fo = 5;
+    }
+    NestedData nested_data = 6;
+    map<string, google.protobuf.Any> mapping = 7;
+}
+
+message PickledMessage {
+    bool foo = 1;
+    int32 bar = 2;
+    repeated string baz = 3;
+}

--- a/tests/inputs/stream_stream/stream_stream.proto
+++ b/tests/inputs/stream_stream/stream_stream.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package stream_stream;
+
+message Message {
+    string body = 1;
+}


### PR DESCRIPTION
Keep only one function `field`, instead of one for every possible data type