### PR TITLE
Remove empty type checking blocks

### DIFF
--- a/src/betterproto2_compiler/plugin/compiler.py
+++ b/src/betterproto2_compiler/plugin/compiler.py
@@ -42,7 +42,7 @@ def outputfile_compiler(output_file: OutputTemplate) -> str:
 
     # Sort imports, delete unused ones
     code = subprocess.check_output(
-        ["ruff", "check", "--select", "I,F401", "--fix", "--silent", "-"],
+        ["ruff", "check", "--select", "I,F401,TCH005", "--fix", "--silent", "-"],
         input=code,
         encoding="utf-8",
     )


### PR DESCRIPTION
The generated code used to contain a lot of blocks:

```python
if TYPE_CHECKING:
    pass
```

This is no longer the case.