### PR TITLE
Stop generating lib code

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -54,10 +54,6 @@ jobs:
         shell: bash
         run: poetry run poe generate
 
-      - name: Compile the lib
-        shell: bash
-        run: poetry run poe generate_lib
-
       - name: Publish the compiled files
         shell: bash
         run: |
@@ -66,7 +62,6 @@ jobs:
           cp -r tests/output_betterproto tests_betterproto
           cp -r tests/output_betterproto_pydantic tests_betterproto_pydantic
           cp -r tests/output_reference tests_reference
-          cp -r tests/output_lib lib
-          git add tests_betterproto tests_betterproto_pydantic tests_reference lib
+          git add tests_betterproto tests_betterproto_pydantic tests_reference
           git commit -m "Add compilation output"
           git push --force origin compiled-test-files


### PR DESCRIPTION
The well known types are now always included in the generated code