### PR TITLE
Prevent UnkownEscapeSequence warnings when comments have backslashes

### DIFF
--- a/src/betterproto2_compiler/plugin/models.py
+++ b/src/betterproto2_compiler/plugin/models.py
@@ -129,10 +129,9 @@ def get_comment(
             # We don't add this space to the generated file.
             lines = [line[1:] if line and line[0] == " " else line for line in lines]
 
-            return "\n".join(lines)
+            return "\n".join(lines).replace("\\","\\\\")
 
     return ""
-
 
 @dataclass(kw_only=True)
 class ProtoContentBase:


### PR DESCRIPTION
## Summary

When generating the python code from protobuf, backslashes in the comments are replaced with double backslashes to prevent UnkownEscapeSequence warnings. E.g., this fixed this library for proto files from https://github.com/OpenSimulationInterface/open-simulation-interface/blob/master/osi_featuredata.proto .

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
    - [ ] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
 
