### PR TITLE
Add serialized descriptorprotos to python classes

### DIFF
--- a/src/betterproto2_compiler/plugin/models.py
+++ b/src/betterproto2_compiler/plugin/models.py
@@ -266,6 +266,10 @@ class MessageCompiler(ProtoContentBase):
 
         return methods_source
 
+    @property
+    def descriptor(self):
+        return self.proto_obj.SerializeToString()
+
 
 def is_map(proto_field_obj: FieldDescriptorProto, parent_message: DescriptorProto) -> bool:
     """True if proto_field_obj is a map, otherwise False."""
@@ -594,6 +598,10 @@ class EnumDefinitionCompiler(ProtoContentBase):
     @property
     def deprecated(self) -> bool:
         return bool(self.proto_obj.options and self.proto_obj.options.deprecated)
+
+    @property
+    def descriptor(self):
+        return self.proto_obj.SerializeToString()
 
 
 @dataclass(kw_only=True)

--- a/src/betterproto2_compiler/templates/template.py.j2
+++ b/src/betterproto2_compiler/templates/template.py.j2
@@ -6,6 +6,10 @@ class {{ enum.py_name | add_to_all }}(betterproto2.Enum):
     """
     {% endif %}
 
+    @staticmethod
+    def _serialized_pb():
+        return {{ enum.descriptor }} 
+
     {% for entry in enum.entries %}
     {{ entry.name }} = {{ entry.value }}
     {% if entry.comment %}
@@ -45,6 +49,10 @@ class {{ message.py_name | add_to_all }}(betterproto2.Message):
     """
     {% endif %}
 
+    @staticmethod
+    def _serialized_pb():
+        return {{ message.descriptor }} 
+    
     {% for field in message.fields %}
     {{ field.get_field_string() }}
     {% if field.comment %}


### PR DESCRIPTION
## Summary

This pull request adds a staticmethod `_serialized_pb` to the generated enums and message classes that returns the serialized DescriptorProto. From that string it is possible to generate die Proto Descriptors, which are needed if you want to write the OSI messages in an [MCAP file](https://github.com/foxglove/mcap/tree/main) using [mcap-protobuf-support](https://github.com/foxglove/mcap/tree/main/python/mcap-protobuf-support)

See this issue for the necessary parts to set the DESCRIPTOR at runtime in python-betterproto2 [python-betterproto2/issues/70](https://github.com/betterproto/python-betterproto2/issues/70).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
    - [ ] This change has an associated test.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
 
