### PR TITLE
Escape triple quotes and backslashes in docstrings

### DIFF
--- a/src/betterproto2_compiler/plugin/models.py
+++ b/src/betterproto2_compiler/plugin/models.py
@@ -129,7 +129,12 @@ def get_comment(
             # We don't add this space to the generated file.
             lines = [line[1:] if line and line[0] == " " else line for line in lines]
 
-            return "\n".join(lines)
+            comment = "\n".join(lines)
+
+            # Escape backslashes and triple quotes
+            comment = comment.replace("\\", "\\\\").replace('"""', '\\"\\"\\"')
+
+            return comment
 
     return ""
 

--- a/tests/inputs/documentation/documentation.proto
+++ b/tests/inputs/documentation/documentation.proto
@@ -56,3 +56,7 @@ service Service { // Documentation of service 3
     // other line 2
     rpc get(Test) returns (Test); // Documentation of method 3
 }
+
+// A comment with backslashes \ and triple quotes """
+// Simple quotes are not escaped "
+message ComplexDocumentation {}


### PR DESCRIPTION
Fix https://github.com/betterproto/python-betterproto2-compiler/pull/55